### PR TITLE
Support for message aggregation by parametrised message

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Synopsis
        print(err)
     end
 
+    -- Send a message to sentry aggregated by first string in message table with rest as parameters
+    local msg = {"%s is %s", "Sentry", "realtime event logging and aggregation platform."}
+    local id, err = rvn:captureMessage(
+      msg,
+      { tags = { abc = "def" } } -- optional
+    )
+    if not id then
+       print(err)
+    end
+
     -- Send an exception to sentry
     local exception = {{
        ["type"]= "SyntaxError",

--- a/raven.lua
+++ b/raven.lua
@@ -359,7 +359,15 @@ function _M.captureMessage(self, message, conf)
    end
 
    clear_tab(_json)
-   _json.message = message
+   if type(message) == "table" then
+      local msg =  message[1]
+      table.remove(message, 1)
+      local params = message
+      setmetatable(params, json.array_mt)
+      _json["sentry.interfaces.Message"] = { message = msg, params = params }
+   else
+      _json.message = message
+    end
 
    _json.culprit = self.get_culprit(conf.trace_level)
 

--- a/resty-raven-1.0.1-1.rockspec
+++ b/resty-raven-1.0.1-1.rockspec
@@ -1,5 +1,5 @@
 package = "resty-raven"
- version = "1.0-2"
+ version = "1.0.1-1"
  source = {
     url = "git://github.com/UseFedora/raven-lua",
  }

--- a/tests/test_http.lua
+++ b/tests/test_http.lua
@@ -91,7 +91,7 @@ function test_capture_message()
       http_respond(client)
 
       assert_not_nil(json)
-      assert_equal("undefined", json.server_name)
+      assert_equal("openresty", json.server_name)
       assert_equal("Sentry is a realtime event logging and aggregation platform.", json.message)
       assert_equal("lua", json.platform)
       assert_not_nil(string_match(json.culprit, "tests/test_http.lua:%d+"))
@@ -122,7 +122,7 @@ function test_capture_exception()
       http_respond(client)
 
       assert_not_nil(json)
-      assert_equal("undefined", json.server_name)
+      assert_equal("openresty", json.server_name)
       assert_equal("lua", json.platform)
       assert_not_nil(string_match(json.culprit, "tests/test_http.lua:%d+"))
       -- Example timestamp: 2014-03-07T00:17:47


### PR DESCRIPTION
This PR adds possibility to parametrise messages, allowing grouping of messages without exception/stack trace

https://docs.sentry.io/data-management/event-grouping/#fallback-grouping 